### PR TITLE
Add to the request model a end_time datetime field.

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -48,6 +48,7 @@ class RequestsController < ApplicationController
     # TODO: Here (state changes from pending -> confirmed)
     # TODO: Once its confirmed, do we notify by email to interpreters and the applicant?
     @request.confirm_after_review
+    @request.set_end_time
     redirect_to '/', flash: { :notice => I18n.t('request.confirm.success', id: @request.user.id).html_safe }
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,6 +4,7 @@ class Request < ActiveRecord::Base
 
   fields do
     start_time    :datetime
+    end_time      :datetime
     place         :string
     duration      :integer
     observations  :text
@@ -21,6 +22,10 @@ class Request < ActiveRecord::Base
   # --- Aux. methods --- #
   def confirm_after_review
     self.update_attribute(:confirmed, true)
+  end
+
+  def set_end_time
+    self.update_attribute(:end_time, start_time + duration.hour)
   end
 
   # --- Permissions --- #

--- a/app/views/taglibs/auto/rapid/forms.dryml
+++ b/app/views/taglibs/auto/rapid/forms.dryml
@@ -16,7 +16,7 @@
 <def tag="form" for="Request">
   <form merge param="default">
     <error-messages param/>
-    <field-list fields="start_time, place, duration, observations, confirmed, interpreter, user" param/>
+    <field-list fields="start_time, end_time, place, duration, observations, confirmed, interpreter, user" param/>
     <div param="actions">
       <submit label="#{ht 'request.actions.save', :default=>['Save']}" param/><or-cancel param="cancel"/>
     </div>

--- a/app/views/taglibs/auto/rapid/pages.dryml
+++ b/app/views/taglibs/auto/rapid/pages.dryml
@@ -268,7 +268,7 @@
     </content-header:>
 
     <content-body: param>
-      <field-list fields="start_time, place, duration, observations, interpreter, user" param/>
+      <field-list fields="start_time, end_time, place, duration, observations, interpreter, user" param/>
     </content-body:>
 
   </page>

--- a/db/migrate/20180507155713_add_end_time_to_request.rb
+++ b/db/migrate/20180507155713_add_end_time_to_request.rb
@@ -1,0 +1,19 @@
+class AddEndTimeToRequest < ActiveRecord::Migration
+  def self.up
+    change_column :users, :administrator, :boolean, :default => false
+    change_column :users, :applicant, :boolean, :default => true
+    change_column :users, :interpreter, :boolean, :default => false
+
+    add_column :requests, :end_time, :datetime
+    change_column :requests, :confirmed, :boolean, :default => false
+  end
+
+  def self.down
+    change_column :users, :administrator, :boolean, default: false
+    change_column :users, :applicant, :boolean, default: true
+    change_column :users, :interpreter, :boolean, default: false
+
+    remove_column :requests, :end_time
+    change_column :requests, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,53 +11,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180410165602) do
+ActiveRecord::Schema.define(version: 20180507155713) do
 
   create_table "addresses", force: :cascade do |t|
-    t.string   "line1",      limit: 255
-    t.string   "line2",      limit: 255
-    t.string   "city",       limit: 255
-    t.string   "state",      limit: 255
-    t.integer  "zip",        limit: 4
-    t.integer  "phone",      limit: 4
+    t.string   "line1"
+    t.string   "line2"
+    t.string   "city"
+    t.string   "state"
+    t.integer  "zip"
+    t.integer  "phone"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",    limit: 4
+    t.integer  "user_id"
   end
 
-  add_index "addresses", ["user_id"], name: "index_addresses_on_user_id", using: :btree
+  add_index "addresses", ["user_id"], name: "index_addresses_on_user_id"
 
   create_table "requests", force: :cascade do |t|
     t.datetime "start_time"
-    t.string   "place",          limit: 255
-    t.integer  "duration",       limit: 4
-    t.text     "observations",   limit: 65535
+    t.string   "place"
+    t.integer  "duration"
+    t.text     "observations"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",        limit: 4
-    t.integer  "interpreter_id", limit: 4
-    t.boolean  "confirmed",                    default: false
+    t.integer  "user_id"
+    t.integer  "interpreter_id"
+    t.boolean  "confirmed",      default: false
+    t.datetime "end_time"
   end
 
-  add_index "requests", ["interpreter_id"], name: "index_requests_on_interpreter_id", using: :btree
-  add_index "requests", ["user_id"], name: "index_requests_on_user_id", using: :btree
+  add_index "requests", ["interpreter_id"], name: "index_requests_on_interpreter_id"
+  add_index "requests", ["user_id"], name: "index_requests_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "crypted_password",          limit: 40
     t.string   "salt",                      limit: 40
-    t.string   "remember_token",            limit: 255
+    t.string   "remember_token"
     t.datetime "remember_token_expires_at"
-    t.string   "name",                      limit: 255
-    t.string   "email_address",             limit: 255
-    t.boolean  "administrator",                         default: false
-    t.boolean  "applicant",                             default: true
-    t.boolean  "interpreter",                           default: false
+    t.string   "name"
+    t.string   "email_address"
+    t.boolean  "administrator",                        default: false
+    t.boolean  "applicant",                            default: true
+    t.boolean  "interpreter",                          default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "state",                     limit: 255, default: "inactive"
+    t.string   "state",                                default: "inactive"
     t.datetime "key_timestamp"
   end
 
-  add_index "users", ["state"], name: "index_users_on_state", using: :btree
+  add_index "users", ["state"], name: "index_users_on_state"
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,51 +14,50 @@
 ActiveRecord::Schema.define(version: 20180507155713) do
 
   create_table "addresses", force: :cascade do |t|
-    t.string   "line1"
-    t.string   "line2"
-    t.string   "city"
-    t.string   "state"
-    t.integer  "zip"
-    t.integer  "phone"
+    t.string   "line1",      limit: 255
+    t.string   "line2",      limit: 255
+    t.string   "city",       limit: 255
+    t.string   "state",      limit: 255
+    t.integer  "zip",        limit: 4
+    t.integer  "phone",      limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
+    t.integer  "user_id",    limit: 4
   end
 
-  add_index "addresses", ["user_id"], name: "index_addresses_on_user_id"
+  add_index "addresses", ["user_id"], name: "index_addresses_on_user_id", using: :btree
 
   create_table "requests", force: :cascade do |t|
     t.datetime "start_time"
-    t.string   "place"
-    t.integer  "duration"
-    t.text     "observations"
+    t.string   "place",          limit: 255
+    t.integer  "duration",       limit: 4
+    t.text     "observations",   limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id"
-    t.integer  "interpreter_id"
-    t.boolean  "confirmed",      default: false
-    t.datetime "end_time"
+    t.integer  "user_id",        limit: 4
+    t.integer  "interpreter_id", limit: 4
+    t.boolean  "confirmed",                    default: false
   end
 
-  add_index "requests", ["interpreter_id"], name: "index_requests_on_interpreter_id"
-  add_index "requests", ["user_id"], name: "index_requests_on_user_id"
+  add_index "requests", ["interpreter_id"], name: "index_requests_on_interpreter_id", using: :btree
+  add_index "requests", ["user_id"], name: "index_requests_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "crypted_password",          limit: 40
     t.string   "salt",                      limit: 40
-    t.string   "remember_token"
+    t.string   "remember_token",            limit: 255
     t.datetime "remember_token_expires_at"
-    t.string   "name"
-    t.string   "email_address"
-    t.boolean  "administrator",                        default: false
-    t.boolean  "applicant",                            default: true
-    t.boolean  "interpreter",                          default: false
+    t.string   "name",                      limit: 255
+    t.string   "email_address",             limit: 255
+    t.boolean  "administrator",                         default: false
+    t.boolean  "applicant",                             default: true
+    t.boolean  "interpreter",                           default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "state",                                default: "inactive"
+    t.string   "state",                     limit: 255, default: "inactive"
     t.datetime "key_timestamp"
   end
 
-  add_index "users", ["state"], name: "index_users_on_state"
+  add_index "users", ["state"], name: "index_users_on_state", using: :btree
 
 end


### PR DESCRIPTION
This field could have been a calculated field, but having it in a db field add's simplicity when making db queries.

***
Añado este campo para simplificar la busqueda de los interpretes disponibles a la hora de asignarles las request.
***